### PR TITLE
Default to non-interactive mode for list command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,16 @@
 
 ## Build, Test, and Development Commands
 - Build: `cargo build` (release: `cargo build --release`).
-- Run: `cargo run -- <args>` (e.g., `cargo run -- list --nointeractive`).
+- Run: `cargo run -- <args>` (e.g., `cargo run -- list` for default non-interactive output).
 - Test: `cargo test` (verbose: `cargo test -- --nocapture`).
 - Format: `cargo fmt --all` (CI enforces `cargo fmt --check`).
 - Lint: `cargo clippy --all-targets -- -D warnings` (CI runs clippy).
 - Release (maintainers): `cargo dist` and `cargo release -x <level>` per CONTRIBUTING.
+
+## CLI Behavior
+- Default: `doist list` outputs tasks in non-interactive mode (suitable for piping/scripting)
+- `-i/--interactive`: Enables continuous interactive mode for task selection and operations
+- `-n/--nointeractive`: Explicitly forces non-interactive mode (supported for backward compatibility but now redundant)
 
 ## Coding Style & Naming Conventions
 - Edition: Rust 2024; use `rustfmt` defaults (4-space indentation).

--- a/README.md
+++ b/README.md
@@ -65,26 +65,30 @@ Now you're authenticated and can use the other functions of the tool.
 
 ### List tasks
 
-Listing tasks and then working with them interactively is the recommended way to
-work with the CLI.
-
-By default the list view shows todays tasks and lets you work with them:
+Listing tasks is the primary way to work with the CLI. By default, tasks are 
+displayed in non-interactive mode, showing today's tasks:
 
 ```bash
 doist
 # Alternatively: `doist list` or `doist l`.
 ```
 
+This will print your tasks to the terminal, suitable for piping or scripting.
+
+For an interactive experience where you can search and select tasks to work with,
+use the interactive flag:
+
+```bash
+doist list --interactive
+# Alternatively: `doist l -i`
+```
+
 This will allow you to type parts of the output until you select the task you
 want to work with (fuzzy search). Selecting will allow you to select various
 other subcommands, like closing, changing due dates or even editing tasks.
 
-You can also disable interactive mode to pipe use the output somewhere else:
-
-```bash
-doist list --nointeractive
-# Alternatively: `doist l -n`
-```
+The `--nointeractive` flag (`-n`) is still supported for backward compatibility,
+but is now redundant since non-interactive is the default.
 
 By default all interactive commands have a filter applied to show the most
 relevant tasks. See the

--- a/src/tasks/list.rs
+++ b/src/tasks/list.rs
@@ -42,9 +42,15 @@ pub struct Params {
 }
 
 /// List lists the tasks of the current user accessing the gateway with the given filter.
-pub async fn list(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
-    if params.continuous && !params.nointeractive {
+pub async fn list(mut params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
+    // If explicitly continuous interactive, use interactive mode
+    if params.continuous {
         return list_interactive(params, gw, cfg).await;
+    }
+    // Default to non-interactive if neither flag was explicitly provided
+    // The nointeractive flag is now redundant but kept for backward compatibility
+    if !params.continuous && !params.nointeractive {
+        params.nointeractive = true;
     }
     match list_action(&params, gw, cfg).await {
         Ok(_) => Ok(()),

--- a/src/tasks/list.rs
+++ b/src/tasks/list.rs
@@ -23,7 +23,7 @@ pub struct Params {
     #[clap(flatten)]
     filter: filter::Filter,
     /// Disables interactive mode and simply displays the list.
-    #[arg(short = 'n', long = "nointeractive")]
+    #[arg(short = 'n', long = "nointeractive", conflicts_with = "continuous")]
     nointeractive: bool,
     #[clap(flatten)]
     project: interactive::Selection<Project>,
@@ -47,9 +47,9 @@ pub async fn list(mut params: Params, gw: &Gateway, cfg: &Config) -> Result<()> 
     if params.continuous {
         return list_interactive(params, gw, cfg).await;
     }
-    // Default to non-interactive if neither flag was explicitly provided
+    // Default to non-interactive if not explicitly set
     // The nointeractive flag is now redundant but kept for backward compatibility
-    if !params.continuous && !params.nointeractive {
+    if !params.nointeractive {
         params.nointeractive = true;
     }
     match list_action(&params, gw, cfg).await {

--- a/tests/commands/list.rs
+++ b/tests/commands/list.rs
@@ -10,6 +10,10 @@ async fn list() -> Result<()> {
         vec!["list", "--nointeractive"],
         vec!["l", "--nointeractive"],
         vec!["--nointeractive"],
+        // Test default non-interactive behavior (no --nointeractive flag)
+        vec!["list"],
+        vec!["l"],
+        vec![],
     ] {
         let cmd = Tool::init().await?;
 


### PR DESCRIPTION
## Summary
- Makes non-interactive mode the default behavior for `doist list` command
- Addresses issue #1 by removing the need for explicit `-n` flag in common usage
- Maintains backward compatibility by keeping all existing flags

## Changes
1. **Modified `src/tasks/list.rs`**: Updated the `list` function to default to non-interactive mode when neither `-i` nor `-n` flags are provided
2. **Updated tests**: Added test cases to verify default non-interactive behavior works correctly
3. **Updated README**: Documented the new default behavior and clarified flag usage

## Behavior
- `doist list` - Now prints tasks in non-interactive mode (default)
- `doist list -i` - Enables continuous interactive mode
- `doist list -n` - Still works but is now redundant

## Testing
- All existing tests pass
- Added new test cases for default behavior without flags
- Verified backward compatibility with existing flags

Fixes #1