### PR TITLE
Fix view command for tasks outside default filter

### DIFF
--- a/src/tasks/filter.rs
+++ b/src/tasks/filter.rs
@@ -46,6 +46,12 @@ impl TaskOrInteractive {
             filter: Filter::new(None),
         }
     }
+    
+    /// Returns the task ID if it was explicitly provided (not for interactive selection)
+    pub fn id(&self) -> Option<&TaskID> {
+        self.id.as_ref()
+    }
+    
     pub async fn task_id(&self, gw: &Gateway, cfg: &Config) -> Result<TaskID> {
         let (id, _) = self.task(gw, cfg).await?;
         Ok(id)

--- a/src/tasks/view.rs
+++ b/src/tasks/view.rs
@@ -1,6 +1,6 @@
 use color_eyre::{Result, eyre::eyre};
 
-use crate::{api::rest::Gateway, comments, config::Config};
+use crate::{api::rest::Gateway, comments, config::Config, tasks::state::State};
 
 use super::filter::TaskOrInteractive;
 
@@ -12,10 +12,36 @@ pub struct Params {
 
 /// Displays full information about a task.
 pub async fn view(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
-    let (id, state) = params.task.task(gw, cfg).await?;
-    let task = state.full_task(state.task(&id).ok_or_else(|| eyre!("no valid task"))?);
-    println!("{task}");
-    if task.0.comment_count > 0 {
+    // When we have a specific task ID, use "all" filter to ensure we can find it
+    let filter = if params.task.id().is_some() {
+        Some("all")
+    } else {
+        None // Use the default filter for interactive selection
+    };
+    
+    // Fetch state with appropriate filter
+    let state = if let Some(f) = filter {
+        State::fetch_tree(Some(f), gw, cfg).await?
+    } else {
+        // Interactive - use the task's filter
+        let (id, state) = params.task.task(gw, cfg).await?;
+        let task = state.full_task(state.task(&id).ok_or_else(|| eyre!("no valid task"))?);
+        println!("{task}");
+        if task.0.comment_count > 0 {
+            let comments = gw.task_comments(&id).await?;
+            comments::list(&comments)
+        }
+        return Ok(());
+    };
+    
+    // Get the task ID (either provided or selected)
+    let id = params.task.id().cloned().ok_or_else(|| eyre!("no task ID"))?;
+    
+    // Find and display the task
+    let task = state.task(&id).ok_or_else(|| eyre!("task not found"))?;
+    let full_task = state.full_task(task);
+    println!("{full_task}");
+    if task.comment_count > 0 {
         let comments = gw.task_comments(&id).await?;
         comments::list(&comments)
     }


### PR DESCRIPTION
## Summary
Fixes the `doist view <task_id>` command to work with tasks that are outside the default filter (today | overdue).

## Problem
Previously, `doist view 9491206042` would fail with "no valid task" error if the task was due in the future (e.g., Sep 2), because the view command was using the default filter which only includes today's and overdue tasks.

## Solution
- When a specific task ID is provided, the view command now uses the "all" filter to ensure the task can be found
- Interactive mode continues to use the user-specified filter as before
- Added a public `id()` method to `TaskOrInteractive` to check if an ID was explicitly provided

## Testing
Tested manually:
- ✅ `doist view 9491206042` now works for future-dated tasks
- ✅ Interactive mode still works with filters
- ✅ Compilation successful, no test regressions

## Before
```
$ doist view 9491206042
Error: 
   0: no valid task
```

## After  
```
$ doist view 9491206042
ID: 9491206042
Priority: p3
Content: Review Chester implementation and test functionality
...
```

Fixes #3