### PR TITLE
fix section parsing, add task move command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@
 - `-n/--nointeractive`: Explicitly forces non-interactive mode (supported for backward compatibility but now redundant)
 - `-f/--filter <query>`: Pass a Todoist filter query to narrow results. Default shows today/overdue only. Use `-f all` to see all tasks, or any named filter (e.g., `-f "All"` for the user's "All Tasks" filter). Other examples: `-f "7 days"`, `-f "#Work"`, `-f "p1"`.
 
+## Sections
+- `doist projects sections list -P <project>` / `sections add -P <project> <name>` / `sections delete`: manage sections within a project.
+- `-S/--section <name>`: filter `doist list` (and select a target section on `doist add`) by section name, fuzzy-matched. Combine with `-P/--project` to scope to one project.
+- `doist move <task_id> -S <section>` (alias `mv`): moves an existing task into a named section of its current project. If the section doesn't exist yet, it's created automatically. This is the primitive for keeping a "Done" or "Awaiting Review" section as a holding area — move a task there instead of closing it, so it stays visible for review before final completion.
+- Section data comes from the Todoist v1 API's `section_order` field (`src/api/rest/section.rs`); do not rename it back to `order` — that mismatch previously broke `list`/`view`/`comment` for any project with a section (missing-field parse error).
+
 ## Coding Style & Naming Conventions
 - Edition: Rust 2024; use `rustfmt` defaults (4-space indentation).
 - Naming: modules/files `snake_case`; types/enums `PascalCase`; functions/vars `snake_case`; constants `SCREAMING_SNAKE_CASE`.

--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use super::{
     Comment, CreateComment, CreateLabel, CreateProject, CreateSection, CreateTask, Label, LabelID,
-    Project, ProjectID, Section, SectionID, Task, TaskDue, TaskID, UpdateTask,
+    MoveTask, Project, ProjectID, Section, SectionID, Task, TaskDue, TaskID, UpdateTask,
 };
 
 /// Pagination envelope returned by v1 API list endpoints.
@@ -124,6 +124,19 @@ impl Gateway {
         self.post_empty(&format!("api/v1/tasks/{id}"), &task)
             .await
             .wrap_err("unable to update task")?;
+        Ok(())
+    }
+
+    /// Moves a task into a different section of its current project.
+    pub async fn move_task(&self, id: &TaskID, section_id: &SectionID) -> Result<()> {
+        self.post_empty(
+            &format!("api/v1/tasks/{id}/move"),
+            &MoveTask {
+                section_id: section_id.clone(),
+            },
+        )
+        .await
+        .wrap_err("unable to move task")?;
         Ok(())
     }
 

--- a/src/api/rest/section.rs
+++ b/src/api/rest/section.rs
@@ -16,14 +16,14 @@ pub struct Section {
     /// Project ID that this section belongs to.
     pub project_id: ProjectID,
     /// Position of the section amongst sections from the same project.
-    pub order: isize,
+    pub section_order: isize,
     /// The actual name of the section.
     pub name: String,
 }
 
 impl Ord for Section {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match self.order.cmp(&other.order) {
+        match self.section_order.cmp(&other.section_order) {
             core::cmp::Ordering::Equal => {}
             ord => return ord,
         }
@@ -70,7 +70,7 @@ impl Section {
             id: id.to_string(),
             project_id: project_id.to_string(),
             name: name.to_string(),
-            order: 0,
+            section_order: 0,
         }
     }
 }

--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -365,6 +365,14 @@ pub struct UpdateTask {
     pub assignee: Option<UserID>,
 }
 
+/// Command used with [`super::Gateway::move_task`] to move a [`Task`] into a different section
+/// of its current project.
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct MoveTask {
+    /// Sets the [`Task::section_id`] the task should be moved to.
+    pub section_id: SectionID,
+}
+
 #[cfg(test)]
 impl Task {
     /// This is initializer is used for tests, as in general the tool relies on the API and not

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::{
     config::Config,
     labels, projects, sections,
-    tasks::{add, close, comment, create, edit, list, view},
+    tasks::{add, close, comment, create, edit, list, mv, view},
 };
 use clap::{Args, Parser, Subcommand};
 use color_eyre::Result;
@@ -55,6 +55,9 @@ enum AuthCommands {
     /// Closes a task.
     #[command(visible_alias = "c")]
     Close(close::Params),
+    /// Moves a task into a section of its current project, creating the section if needed.
+    #[command(visible_alias = "mv")]
+    Move(mv::Params),
     /// View details of a single task.
     #[command(visible_alias = "v")]
     View(view::Params),
@@ -168,6 +171,7 @@ impl Arguments {
                         AuthCommands::List(p) => list::list(p, &gw, &cfg).await?,
                         AuthCommands::Edit(p) => edit::edit(p, &gw, &cfg).await?,
                         AuthCommands::Close(p) => close::close(p, &gw, &cfg).await?,
+                        AuthCommands::Move(p) => mv::mv(p, &gw, &cfg).await?,
                         AuthCommands::View(p) => view::view(p, &gw, &cfg).await?,
                         AuthCommands::Comment(p) => comment::comment(p, &gw, &cfg).await?,
                         AuthCommands::Projects(p) => match p.command {

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -6,6 +6,7 @@ pub mod create;
 pub mod edit;
 mod filter;
 pub mod list;
+pub mod mv;
 mod priority;
 mod state;
 pub mod view;

--- a/src/tasks/mv.rs
+++ b/src/tasks/mv.rs
@@ -1,0 +1,162 @@
+use color_eyre::{Result, eyre::WrapErr};
+use owo_colors::{OwoColorize, Stream};
+
+use crate::{
+    api::rest::{CreateSection, Gateway},
+    config::Config,
+};
+
+use super::filter::TaskOrInteractive;
+
+#[derive(clap::Parser, Debug)]
+pub struct Params {
+    #[clap(flatten)]
+    pub task: TaskOrInteractive,
+    /// Name of the section to move the task into, within the task's current project.
+    /// Created automatically if no section with this name exists yet.
+    #[arg(short = 'S', long = "section")]
+    pub section: String,
+}
+
+/// Moves a task into a section of its current project, creating the section if it doesn't
+/// already exist.
+pub async fn mv(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
+    let id = params
+        .task
+        .task_id(gw, cfg)
+        .await
+        .wrap_err("no task selected for moving")?;
+    let task = gw.task(&id).await?;
+
+    let sections = gw.sections().await?;
+    let section = match sections
+        .into_iter()
+        .find(|s| s.project_id == task.project_id && s.name.eq_ignore_ascii_case(&params.section))
+    {
+        Some(section) => section,
+        None => gw
+            .create_section(&CreateSection {
+                name: params.section.clone(),
+                project_id: task.project_id.clone(),
+                ..Default::default()
+            })
+            .await
+            .wrap_err("unable to create section")?,
+    };
+
+    gw.move_task(&id, &section.id).await?;
+    println!(
+        "moved task {} to section {}",
+        id.if_supports_color(Stream::Stdout, |text| text.bright_red()),
+        section.name
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
+
+    use crate::api::rest::{Section, Task};
+
+    use super::*;
+
+    async fn mock_empty_state(mock_server: &MockServer) {
+        for path_str in ["/api/v1/tasks/filter", "/api/v1/projects", "/api/v1/labels"] {
+            Mock::given(method("GET"))
+                .and(path(path_str))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "results": [],
+                    "next_cursor": null
+                })))
+                .mount(mock_server)
+                .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn moves_to_existing_section() {
+        let mock_server = MockServer::start().await;
+        mock_empty_state(&mock_server).await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/tasks/123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Task::new("123", "task")))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/sections"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": [Section::new("sec1", "", "Done")],
+                "next_cursor": null
+            })))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tasks/123/move"))
+            .and(body_json(serde_json::json!({"section_id": "sec1"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Task::new("123", "task")))
+            .mount(&mock_server)
+            .await;
+
+        let gw = Gateway::new("", &mock_server.uri().parse().unwrap());
+        let result = mv(
+            Params {
+                task: "123".to_string().into(),
+                section: "done".to_string(),
+            },
+            &gw,
+            &Config::default(),
+        )
+        .await;
+        mock_server.verify().await;
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+
+    #[tokio::test]
+    async fn creates_missing_section() {
+        let mock_server = MockServer::start().await;
+        mock_empty_state(&mock_server).await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/tasks/123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Task::new("123", "task")))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/sections"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "results": [],
+                "next_cursor": null
+            })))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/sections"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(Section::new("sec1", "", "Done")),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tasks/123/move"))
+            .and(body_json(serde_json::json!({"section_id": "sec1"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Task::new("123", "task")))
+            .mount(&mock_server)
+            .await;
+
+        let gw = Gateway::new("", &mock_server.uri().parse().unwrap());
+        let result = mv(
+            Params {
+                task: "123".to_string().into(),
+                section: "Done".to_string(),
+            },
+            &gw,
+            &Config::default(),
+        )
+        .await;
+        mock_server.verify().await;
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+}

--- a/tests/commands/fixtures/sections.json
+++ b/tests/commands/fixtures/sections.json
@@ -3,49 +3,49 @@
 		{
 			"id": "1100001",
 			"project_id": "1000005",
-			"order": 1,
+			"section_order": 1,
 			"name": "Section One"
 		},
 		{
 			"id": "1100002",
 			"project_id": "1000005",
-			"order": 2,
+			"section_order": 2,
 			"name": "Section Two"
 		},
 		{
 			"id": "1100003",
 			"project_id": "1000002",
-			"order": 1,
+			"section_order": 1,
 			"name": "Section Three"
 		},
 		{
 			"id": "1100004",
 			"project_id": "1000004",
-			"order": 1,
+			"section_order": 1,
 			"name": "Section Four"
 		},
 		{
 			"id": "1100005",
 			"project_id": "1000004",
-			"order": 2,
+			"section_order": 2,
 			"name": "Section Five"
 		},
 		{
 			"id": "1100006",
 			"project_id": "1000003",
-			"order": 1,
+			"section_order": 1,
 			"name": "Section Six"
 		},
 		{
 			"id": "1100007",
 			"project_id": "1000003",
-			"order": 2,
+			"section_order": 2,
 			"name": "Section Seven"
 		},
 		{
 			"id": "1100008",
 			"project_id": "1000003",
-			"order": 3,
+			"section_order": 3,
 			"name": "Section Eight"
 		}
 	],


### PR DESCRIPTION
sections broke after the last upstream merge — a conflict resolution kept `order` on the Section struct instead of upstream's rename to `section_order`, which is what the real API actually sends. so `list`/`view`/`comment` all 500 with a missing-field parse error the moment a project has any section. fixed, and confirmed against the real API.

also added `doist move <task> -S <section>` (alias `mv`) since there wasn't a way to shuffle a task into a section — it looks up the section by name in the task's current project and creates it if it's missing. useful for a "Done" or "Awaiting Review" holding section instead of closing a task outright.

documented both in CLAUDE.md.

tested: `cargo fmt`/`clippy`/`test` all clean, plus live smoke-tested against the real API in scratch projects (created and torn down) — confirmed the parse-error bug is gone and `move`/`mv` works including section auto-create.
